### PR TITLE
feat(zk-protocol): structure the public signals array obtained while generating a proof from snarkjs

### DIFF
--- a/packages/protocols/src/rln.ts
+++ b/packages/protocols/src/rln.ts
@@ -1,10 +1,40 @@
 import { MerkleProof } from "@zk-kit/incremental-merkle-tree"
 import { poseidon } from "circomlibjs"
-import { StrBigInt } from "./types"
+import { groth16 } from "snarkjs"
+import { FullProof, RLNPublicSignals, StrBigInt } from "./types"
 import { Fq, genSignalHash } from "./utils"
 import ZkProtocol from "./zk-protocol"
 
 export default class RLN extends ZkProtocol {
+  /**
+   * The number of public signals that should be returned by snarkjs when generating a proof.
+   */
+  private static PUBLIC_SIGNALS_COUNT: number = 6
+
+  /**
+   * Generates a SnarkJS full proof with Groth16.
+   * @param witness The parameters for creating the proof.
+   * @param wasmFilePath The WASM file path.
+   * @param finalZkeyPath The ZKey file path.
+   * @returns The full SnarkJS proof.
+   */
+  public static async genProof(witness: any, wasmFilePath: string, finalZkeyPath: string): Promise<FullProof> {
+    const { proof, publicSignalsArray } = await groth16.fullProve(witness, wasmFilePath, finalZkeyPath, null)
+
+    if (publicSignalsArray.length !== RLN.PUBLIC_SIGNALS_COUNT) throw new Error("Error while generating proof")
+
+    const publicSignals: RLNPublicSignals = {
+      yShare: publicSignalsArray[0],
+      merkleRoot: publicSignalsArray[1],
+      internalNullifier: publicSignalsArray[2],
+      signalHash: publicSignalsArray[3],
+      epoch: publicSignalsArray[4],
+      rlnIdentifier: publicSignalsArray[5]
+    }
+
+    return { proof, publicSignals }
+  }
+
   /**
    * Creates witness for rln proof
    * @param identitySecret identity secret

--- a/packages/protocols/src/types/index.ts
+++ b/packages/protocols/src/types/index.ts
@@ -10,7 +10,16 @@ export type Proof = {
 
 export type FullProof = {
   proof: Proof
-  publicSignals: StrBigInt[]
+  publicSignals: PublicSignals
+}
+
+export type PublicSignals = {
+  yShare: StrBigInt
+  merkleRoot: StrBigInt
+  internalNullifier: StrBigInt
+  signalHash: StrBigInt
+  epoch: StrBigInt
+  rlnIdentifier: StrBigInt
 }
 
 export type SolidityProof = StrBigInt[]

--- a/packages/protocols/src/types/index.ts
+++ b/packages/protocols/src/types/index.ts
@@ -10,16 +10,23 @@ export type Proof = {
 
 export type FullProof = {
   proof: Proof
-  publicSignals: PublicSignals
+  publicSignals: RLNPublicSignals | SemaphorePublicSignals
 }
 
-export type PublicSignals = {
+export type RLNPublicSignals = {
   yShare: StrBigInt
   merkleRoot: StrBigInt
   internalNullifier: StrBigInt
   signalHash: StrBigInt
   epoch: StrBigInt
   rlnIdentifier: StrBigInt
+}
+
+export type SemaphorePublicSignals = {
+  merkleRoot: StrBigInt
+  nullifierHash: StrBigInt
+  signalHash: StrBigInt
+  externalNullifier: StrBigInt
 }
 
 export type SolidityProof = StrBigInt[]

--- a/packages/protocols/src/zk-protocol.ts
+++ b/packages/protocols/src/zk-protocol.ts
@@ -1,37 +1,8 @@
 /* istanbul ignore file */
 import { groth16 } from "snarkjs"
-import { FullProof, PublicSignals, SolidityProof, StrBigInt } from "./types"
+import { FullProof, SolidityProof, StrBigInt } from "./types"
 
 export default class ZkProtocol {
-  /**
-   * The number of public signals that should be returned by snarkjs when generating a proof.
-   */
-  private static PUBLIC_SIGNALS_COUNT: number = 6
-
-  /**
-   * Generates a SnarkJS full proof with Groth16.
-   * @param witness The parameters for creating the proof.
-   * @param wasmFilePath The WASM file path.
-   * @param finalZkeyPath The ZKey file path.
-   * @returns The full SnarkJS proof.
-   */
-  public static async genProof(witness: any, wasmFilePath: string, finalZkeyPath: string): Promise<FullProof> {
-    const { proof, publicSignalsArray } = await groth16.fullProve(witness, wasmFilePath, finalZkeyPath, null)
-
-    if (publicSignalsArray.length !== ZkProtocol.PUBLIC_SIGNALS_COUNT) throw new Error("Error while generating proof")
-
-    const publicSignals: PublicSignals = {
-      yShare: publicSignalsArray[0],
-      merkleRoot: publicSignalsArray[1],
-      internalNullifier: publicSignalsArray[2],
-      signalHash: publicSignalsArray[3],
-      epoch: publicSignalsArray[4],
-      rlnIdentifier: publicSignalsArray[5]
-    }
-
-    return { proof, publicSignals }
-  }
-
   /**
    * Verifies a zero-knowledge SnarkJS proof.
    * @param verificationKey The zero-knowledge verification key.

--- a/packages/protocols/tests/rln.test.ts
+++ b/packages/protocols/tests/rln.test.ts
@@ -4,6 +4,7 @@ import * as fs from "fs"
 import * as path from "path"
 import { RLN } from "../src"
 import { generateMerkleProof, genExternalNullifier, genSignalHash } from "../src/utils"
+import { PublicSignals } from "../src/types"
 
 describe("RLN", () => {
   const zkeyFiles = "./packages/protocols/zkeyFiles"
@@ -65,7 +66,15 @@ describe("RLN", () => {
       const witness = RLN.genWitness(secretHash, merkleProof, epoch, signal, rlnIdentifier)
 
       const [y, nullifier] = RLN.calculateOutput(secretHash, BigInt(epoch), rlnIdentifier, signalHash)
-      const publicSignals = [y, merkleProof.root, nullifier, signalHash, epoch, rlnIdentifier]
+
+      const publicSignals: PublicSignals = {
+        yShare: y,
+        merkleRoot: merkleProof.root,
+        internalNullifier: nullifier,
+        signalHash,
+        epoch,
+        rlnIdentifier
+      }
 
       const vkeyPath = path.join(zkeyFiles, "rln", "verification_key.json")
       const vKey = JSON.parse(fs.readFileSync(vkeyPath, "utf-8"))
@@ -77,6 +86,7 @@ describe("RLN", () => {
       const response = await RLN.verifyProof(vKey, { proof: fullProof.proof, publicSignals })
 
       expect(response).toBe(true)
+      expect(fullProof.publicSignals).toEqual(publicSignals)
     }, 30000)
 
     it("Should retrieve user secret after spaming", () => {

--- a/packages/protocols/tests/rln.test.ts
+++ b/packages/protocols/tests/rln.test.ts
@@ -4,7 +4,7 @@ import * as fs from "fs"
 import * as path from "path"
 import { RLN } from "../src"
 import { generateMerkleProof, genExternalNullifier, genSignalHash } from "../src/utils"
-import { PublicSignals } from "../src/types"
+import { RLNPublicSignals } from "../src/types"
 
 describe("RLN", () => {
   const zkeyFiles = "./packages/protocols/zkeyFiles"
@@ -67,7 +67,7 @@ describe("RLN", () => {
 
       const [y, nullifier] = RLN.calculateOutput(secretHash, BigInt(epoch), rlnIdentifier, signalHash)
 
-      const publicSignals: PublicSignals = {
+      const publicSignals: RLNPublicSignals = {
         yShare: y,
         merkleRoot: merkleProof.root,
         internalNullifier: nullifier,

--- a/packages/protocols/tests/semaphore.test.ts
+++ b/packages/protocols/tests/semaphore.test.ts
@@ -3,6 +3,7 @@ import { getCurveFromName } from "ffjavascript"
 import fs from "fs"
 import path from "path"
 import { Semaphore } from "../src"
+import { SemaphorePublicSignals } from "../src/types"
 import { generateMerkleProof, genExternalNullifier, genSignalHash } from "../src/utils"
 
 describe("Semaphore", () => {
@@ -64,11 +65,18 @@ describe("Semaphore", () => {
       const vkeyPath = path.join("./packages/protocols/zkeyFiles", "semaphore", "verification_key.json")
       const vKey = JSON.parse(fs.readFileSync(vkeyPath, "utf-8"))
       const nullifierHash = Semaphore.genNullifierHash(externalNullifier, identity.getNullifier())
-      const publicSignals = [merkleProof.root.toString(), nullifierHash, genSignalHash(signal), externalNullifier]
+
+      const publicSignals: SemaphorePublicSignals = {
+        merkleRoot: merkleProof.root.toString(),
+        nullifierHash,
+        signalHash: genSignalHash(signal),
+        externalNullifier
+      }
 
       const response = await Semaphore.verifyProof(vKey, { proof: fullProof.proof, publicSignals })
 
       expect(response).toBe(true)
+      expect(fullProof.publicSignals).toEqual(publicSignals)
     }, 30000)
   })
 })


### PR DESCRIPTION
The generated proof using snarkjs will return an object of type PublicSignals for the public signals
instead of the array

BREAKING CHANGE: The generated proof using snarkjs will return an object of type PublicSignals for
the public signals instead of the array

<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The generated proof using snarkjs returns an array of the public signals, the same array returned by snarkjs.

Issue Number: N/A

## What is the new behavior?

The generated proof using snarkjs will return an object of type PublicSignals for the public signals
instead of the array

-
-
-

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Existing applications should update the way they access the public signals.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
