### PR TITLE
fix(incremental-merkle-tree): merkle tree supports zero leaves. Merkle proof fails for zero value

### DIFF
--- a/packages/incremental-merkle-tree/package.json
+++ b/packages/incremental-merkle-tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zk-kit/incremental-merkle-tree",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Incremental Merkle tree implementation in TypeScript.",
   "license": "MIT",
   "iife": "dist/index.js",

--- a/packages/incremental-merkle-tree/src/insert.ts
+++ b/packages/incremental-merkle-tree/src/insert.ts
@@ -11,10 +11,6 @@ export default function insert(
 ): Node {
   checkParameter(leaf, "leaf", "number", "string", "bigint")
 
-  if (leaf === zeroes[0]) {
-    throw new Error("The leaf cannot be a zero value")
-  }
-
   if (nodes[0].length >= arity ** depth) {
     throw new Error("The tree is full")
   }

--- a/packages/incremental-merkle-tree/tests/index.test.ts
+++ b/packages/incremental-merkle-tree/tests/index.test.ts
@@ -37,18 +37,12 @@ describe("Incremental Merkle Tree", () => {
         expect(tree.arity).toEqual(arity)
       })
 
-      it("Should not insert a zero leaf", () => {
-        const fun = () => tree.insert(BigInt(0))
-
-        expect(fun).toThrow("The leaf cannot be a zero value")
-      })
-
       it("Should not insert a leaf in a full tree", () => {
         const fullTree = new IncrementalMerkleTree(poseidon, 1, BigInt(0), 3)
 
+        fullTree.insert(BigInt(0))
         fullTree.insert(BigInt(1))
         fullTree.insert(BigInt(2))
-        fullTree.insert(BigInt(3))
 
         const fun = () => fullTree.insert(BigInt(4))
 

--- a/packages/protocols/package.json
+++ b/packages/protocols/package.json
@@ -38,7 +38,7 @@
     "@ethersproject/bytes": "^5.5.0",
     "@ethersproject/solidity": "^5.5.0",
     "@ethersproject/strings": "^5.5.0",
-    "@zk-kit/incremental-merkle-tree": "^0.4.2",
+    "@zk-kit/incremental-merkle-tree": "^0.4.3",
     "circomlibjs": "0.0.8",
     "ffjavascript": "0.2.38",
     "snarkjs": "^0.4.13"

--- a/packages/protocols/src/utils.ts
+++ b/packages/protocols/src/utils.ts
@@ -64,6 +64,8 @@ export function generateMerkleProof(
   leaves: StrBigInt[],
   leaf: StrBigInt
 ): MerkleProof {
+  if (leaf === zeroValue) throw new Error("Can't generate a proof for a zero leaf")
+
   const tree = generateMerkleTree(depth, zeroValue, arity, leaves)
 
   const leafIndex = tree.leaves.indexOf(BigInt(leaf))

--- a/packages/protocols/tests/rln.test.ts
+++ b/packages/protocols/tests/rln.test.ts
@@ -48,6 +48,16 @@ describe("RLN", () => {
       expect(typeof witness).toBe("object")
     })
 
+    it("Should throw an exception for a zero leaf", () => {
+      const zeroIdCommitment = BigInt(0)
+      const leaves = Object.assign([], identityCommitments)
+      leaves.push(zeroIdCommitment)
+
+      const fun = () => generateMerkleProof(15, zeroIdCommitment, 2, leaves, zeroIdCommitment)
+
+      expect(fun).toThrow("Can't generate a proof for a zero leaf")
+    })
+
     // eslint-disable-next-line jest/no-disabled-tests
     it.skip("Should generate rln proof and verify it", async () => {
       const identity = new ZkIdentity()


### PR DESCRIPTION
The incremental-merkle-tree can be constructed with any value, including zeros. The generation of
merkle proof will fail for zero value.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Current behavior doesn't allow the creation of a merkle tree with a zero leaf.

Issue Number: N/A

## What is the new behavior?

The new behavior allows the creation of a merkle tree with a zero leaf, while the generation of a merkle proof for a zero commitment will fail.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
