### PR TITLE
chore: use `crypto-js/sha256` instead of `js-sha256`

### DIFF
--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.3.0",
+    "@types/crypto-js": "^4.1.1",
     "rollup-plugin-cleanup": "^3.2.1",
     "typedoc": "^0.22.11"
   },
@@ -38,6 +39,6 @@
     "@ethersproject/bignumber": "^5.5.0",
     "@ethersproject/random": "^5.5.1",
     "circomlibjs": "0.0.8",
-    "js-sha256": "^0.9.0"
+    "crypto-js": "^4.1.1"
   }
 }

--- a/packages/identity/src/utils.ts
+++ b/packages/identity/src/utils.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from "@ethersproject/bignumber"
 import { randomBytes } from "@ethersproject/random"
-import { sha256 as _sha256 } from "js-sha256"
+import _sha256 from "crypto-js/sha256"
 
 /**
  * Returns an hexadecimal sha256 hash of the message passed as parameter.
@@ -8,11 +8,9 @@ import { sha256 as _sha256 } from "js-sha256"
  * @returns The hexadecimal hash of the message.
  */
 export function sha256(message: string): string {
-  const hash = _sha256.create()
+  const hash = _sha256(message)
 
-  hash.update(message)
-
-  return hash.hex()
+  return hash.toString()
 }
 
 /**

--- a/packages/identity/yarn.lock
+++ b/packages/identity/yarn.lock
@@ -245,6 +245,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/crypto-js@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.1.1.tgz#602859584cecc91894eb23a4892f38cfa927890d"
+  integrity sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -751,6 +756,11 @@ crypto-browserify@3.12.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 d@1, d@^1.0.1:
   version "1.0.1"
@@ -1617,11 +1627,6 @@ js-cleanup@^1.2.0:
     magic-string "^0.25.7"
     perf-regexes "^1.0.1"
     skip-regex "^1.0.2"
-
-js-sha256@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
-  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
 
 js-sha3@0.8.0, js-sha3@^0.8.0:
   version "0.8.0"

--- a/packages/sparse-merkle-tree/README.md
+++ b/packages/sparse-merkle-tree/README.md
@@ -90,11 +90,11 @@ or [JSDelivr](https://www.jsdelivr.com/):
 
 ```typescript
 import { SparseMerkleTree } from "@zk-kit/sparse-merkle-tree"
-import { sha256 } from "js-sha256"
+import sha256 from "crypto-js/sha256"
 import { poseidon } from "circomlibjs"
 
 // Hexadecimal hashes.
-const hash = (childNodes: ChildNodes) => sha256(childNodes.join(""))
+const hash = (childNodes: ChildNodes) => sha256(childNodes.join("")).toString()
 const tree = new SparseMerkleTree(hash)
 
 // Big number hashes.

--- a/packages/sparse-merkle-tree/package.json
+++ b/packages/sparse-merkle-tree/package.json
@@ -41,7 +41,8 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.3.0",
     "circomlibjs": "^0.0.8",
-    "js-sha256": "^0.9.0",
+    "crypto-js": "^4.1.1",
+    "@types/crypto-js": "^4.1.1",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-terser": "^7.0.2",
     "typedoc": "^0.22.11"

--- a/packages/sparse-merkle-tree/tests/index.test.ts
+++ b/packages/sparse-merkle-tree/tests/index.test.ts
@@ -1,9 +1,9 @@
 import { poseidon, smt } from "circomlibjs"
-import { sha256 } from "js-sha256"
+import sha256 from "crypto-js/sha256"
 import { ChildNodes, SparseMerkleTree } from "../src"
 
 describe("Sparse Merkle tree", () => {
-  const hash = (childNodes: ChildNodes) => sha256(childNodes.join(""))
+  const hash = (childNodes: ChildNodes) => sha256(childNodes.join("")).toString()
   const testKeys = ["a", "3", "2b", "20", "9", "17"]
 
   describe("Create hexadecimal trees", () => {
@@ -177,7 +177,7 @@ describe("Sparse Merkle tree", () => {
     })
 
     it("Should not create a big number tree if the hash function does not return a big number", () => {
-      const hash = (childNodes: ChildNodes) => sha256(childNodes.join(""))
+      const hash = (childNodes: ChildNodes) => sha256(childNodes.join("")).toString()
 
       const fun = () => new SparseMerkleTree(hash, true)
 

--- a/packages/sparse-merkle-tree/yarn.lock
+++ b/packages/sparse-merkle-tree/yarn.lock
@@ -258,6 +258,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/crypto-js@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.1.1.tgz#602859584cecc91894eb23a4892f38cfa927890d"
+  integrity sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -802,6 +807,11 @@ crypto-browserify@3.12.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 d@1, d@^1.0.1:
   version "1.0.1"
@@ -1692,11 +1702,6 @@ js-cleanup@^1.2.0:
     magic-string "^0.25.7"
     perf-regexes "^1.0.1"
     skip-regex "^1.0.2"
-
-js-sha256@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
-  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
 
 js-sha3@0.8.0, js-sha3@^0.8.0:
   version "0.8.0"


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`js-sha256` hasn't been updated for a long time. It causes frontend `referenceError` in some config.
Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
- Use `crypto-js/sha256` instead of `js-sha256`
- hash element with `sha256(message)`
- stringify sha256 hash with `.toString()`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
